### PR TITLE
Modify toolchain version in go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module shotgun_code
 
-go 1.24
+go 1.24.0
 
 require github.com/wailsapp/wails/v2 v2.10.1
 


### PR DESCRIPTION
I dont know if this only happens in OSX but, there is no`1.24` toolchain for Go.
```
shotgun_code ➤ wails dev                                                                                                                                                                                                                                
Wails CLI v2.10.1

Executing: go mod tidy
go: downloading go1.24 (darwin/arm64)
go: download go1.24 for darwin/arm64: toolchain not available
```
`1.24.0` works fine.
```
shotgun_code ➤ wails dev                                                                                                                                                                                                                                git:main*
Wails CLI v2.10.1

Executing: go mod tidy
  • Generating bindings: Done.
  • Installing frontend dependencies: Done.
  • Compiling frontend: Done.

> shotgun-app-frontend@0.0.0 dev
> vite
```