### PR TITLE
feat: Integrate OpenRouter API for code suggestions

### DIFF
--- a/frontend/src/components/CentralPanel.vue
+++ b/frontend/src/components/CentralPanel.vue
@@ -13,6 +13,7 @@ import Step1CopyStructure from './steps/Step1PrepareContext.vue';
 import Step2ComposePrompt from './steps/Step2ComposePrompt.vue';
 import Step3ExecutePrompt from './steps/Step3ExecutePrompt.vue';
 import Step4ApplyPatch from './steps/Step4ApplyPatch.vue';
+import OpenRouterPanel from './OpenRouterPanel.vue'; // Import the new panel
 
 const props = defineProps({
   currentStep: { type: Number, required: true },

--- a/frontend/src/components/MainLayout.vue
+++ b/frontend/src/components/MainLayout.vue
@@ -55,6 +55,8 @@ import HorizontalStepper from './HorizontalStepper.vue';
 import LeftSidebar from './LeftSidebar.vue';
 import CentralPanel from './CentralPanel.vue';
 import BottomConsole from './BottomConsole.vue';
+// OpenRouterPanel is rendered by CentralPanel, but importing here for clarity on the new step
+import OpenRouterPanel from './OpenRouterPanel.vue';
 import { ListFiles, RequestShotgunContextGeneration, SelectDirectory as SelectDirectoryGo, StartFileWatcher, StopFileWatcher, SetUseGitignore, SetUseCustomIgnore, SplitShotgunDiff } from '../../wailsjs/go/main/App';
 import { EventsOn, Environment } from '../../wailsjs/runtime/runtime';
 
@@ -64,6 +66,7 @@ const steps = ref([
   { id: 2, title: 'Compose Prompt', completed: false, description: 'Provide a prompt to the LLM based on the project context to generate a code diff.' },
   { id: 3, title: 'Execute Prompt', completed: false, description: 'Paste a large shotgunDiff and split it into smaller, manageable parts.' },
   { id: 4, title: 'Apply Patch', completed: false, description: 'Copy and apply the smaller diff parts to your project.' },
+  { id: 5, title: 'Get Suggestions', completed: false, description: 'Use OpenRouter API to get suggestions on your diff.' },
 ]);
 
 const logMessages = ref([]);
@@ -444,6 +447,21 @@ async function handleStepAction(actionName, payload) {
     case 'finishSplitting':
       addLog("Finished with split diffs.", 'info', 'bottom');
       if (currentStepObj) currentStepObj.completed = true;
+      // Potentially navigate to step 5 if it's the next logical step
+      // For now, user clicks to navigate or it's handled by completing step 3/4
+      break;
+    case 'openRouterSuggestionsObtained':
+      addLog("OpenRouter suggestions obtained.", "success", "bottom");
+      if (currentStep.value === 5) { // Ensure we are on the correct step
+        const step5 = steps.value.find(s => s.id === 5);
+        if (step5) step5.completed = true;
+        // addLog(`Suggestions: ${payload}`, 'debug', 'bottom'); // Payload might be large
+      }
+      // Decide if we navigate to another step or stay
+      break;
+    case 'openRouterSuggestionsError':
+      addLog(`OpenRouter error: ${payload}`, "error", "bottom");
+      // Step 5 remains incomplete
       break;
     default:
       addLog(`Unknown action: ${actionName}`, 'error', 'bottom');

--- a/frontend/src/components/OpenRouterPanel.vue
+++ b/frontend/src/components/OpenRouterPanel.vue
@@ -1,0 +1,189 @@
+<template>
+  <div class="openrouter-panel">
+    <h2>OpenRouter Configuration & Suggestions</h2>
+
+    <div class="form-group">
+      <label for="apiKey">OpenRouter API Key:</label>
+      <input type="password" id="apiKey" v-model="apiKey" placeholder="sk-or-..." />
+    </div>
+
+    <div class="form-group">
+      <label for="modelName">OpenRouter Model:</label>
+      <input type="text" id="modelName" v-model="modelName" />
+    </div>
+
+    <div class="form-group">
+      <label for="systemPrompt">System Prompt:</label>
+      <textarea id="systemPrompt" v-model="systemPrompt" rows="4"></textarea>
+    </div>
+
+    <div class="form-group">
+      <label>Git Diff to Analyze (Read-only):</label>
+      <pre class="diff-display"><code>{{ shotgunGitDiff || 'No diff content provided.' }}</code></pre>
+    </div>
+
+    <button @click="getSuggestions" :disabled="isLoading">
+      <span v-if="isLoading">Loading...</span>
+      <span v-else>Get Suggestions</span>
+    </button>
+
+    <div v-if="errorMsg" class="error-message">
+      {{ errorMsg }}
+    </div>
+
+    <div v-if="suggestions" class="suggestions-output">
+      <h3>Suggestions:</h3>
+      <pre><code>{{ suggestions }}</code></pre>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { ref, defineProps, defineEmits } from 'vue';
+import { CallOpenRouter } from '../../wailsjs/go/main/App';
+
+const props = defineProps({
+  shotgunGitDiff: String,
+});
+
+const emits = defineEmits(['suggestions-obtained', 'suggestions-error']);
+
+const apiKey = ref('');
+const modelName = ref('openai/gpt-3.5-turbo'); // Default model
+const systemPrompt = ref(
+  'You are a code review assistant. Analyze the provided diff and return your suggestions as a code block or in a diff format.'
+);
+const isLoading = ref(false);
+const errorMsg = ref('');
+const suggestions = ref('');
+
+async function getSuggestions() {
+  isLoading.value = true;
+  errorMsg.value = '';
+  suggestions.value = '';
+
+  if (!apiKey.value) {
+    errorMsg.value = 'OpenRouter API Key is required.';
+    isLoading.value = false;
+    emits('suggestions-error', errorMsg.value);
+    return;
+  }
+
+  if (!props.shotgunGitDiff) {
+    errorMsg.value = 'Diff content is empty. Cannot get suggestions.';
+    isLoading.value = false;
+    emits('suggestions-error', errorMsg.value);
+    return;
+  }
+
+  try {
+    const result = await CallOpenRouter(
+      apiKey.value,
+      modelName.value,
+      props.shotgunGitDiff,
+      systemPrompt.value
+    );
+    suggestions.value = result;
+    emits('suggestions-obtained', result);
+  } catch (err) {
+    console.error('Error calling OpenRouter:', err);
+    errorMsg.value = `Failed to get suggestions: ${err.message || err}`;
+    emits('suggestions-error', errorMsg.value);
+  } finally {
+    isLoading.value = false;
+  }
+}
+</script>
+
+<style scoped>
+.openrouter-panel {
+  padding: 20px;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  margin-bottom: 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 15px;
+}
+
+.form-group {
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+}
+
+.form-group label {
+  font-weight: bold;
+}
+
+input[type="text"],
+input[type="password"],
+textarea {
+  width: 100%;
+  padding: 8px;
+  border: 1px solid #ddd;
+  border-radius: 4px;
+  box-sizing: border-box;
+}
+
+textarea {
+  resize: vertical;
+  min-height: 60px;
+}
+
+.diff-display {
+  background-color: #f0f0f0;
+  padding: 10px;
+  border-radius: 4px;
+  max-height: 200px;
+  overflow-y: auto;
+  white-space: pre-wrap; /* Allows wrapping long lines */
+  word-break: break-all; /* Breaks long words/lines if necessary */
+}
+
+button {
+  padding: 10px 15px;
+  background-color: #007bff;
+  color: white;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  transition: background-color 0.2s;
+}
+
+button:disabled {
+  background-color: #aaa;
+  cursor: not-allowed;
+}
+
+button:not(:disabled):hover {
+  background-color: #0056b3;
+}
+
+.error-message {
+  color: red;
+  border: 1px solid red;
+  padding: 10px;
+  border-radius: 4px;
+  background-color: #ffe0e0;
+}
+
+.suggestions-output {
+  margin-top: 15px;
+}
+
+.suggestions-output h3 {
+  margin-bottom: 5px;
+}
+
+.suggestions-output pre {
+  background-color: #f9f9f9;
+  border: 1px solid #eee;
+  padding: 10px;
+  border-radius: 4px;
+  white-space: pre-wrap;
+  word-break: break-all;
+  max-height: 400px;
+  overflow-y: auto;
+}
+</style>


### PR DESCRIPTION
This commit introduces a new feature allowing you to get code suggestions from the OpenRouter API based on a diff.

Backend:
- Added `CallOpenRouter` function to `app.go` to handle requests to the OpenRouter API (/v1/chat/completions).
- The function constructs the payload, sets necessary headers (including Authorization with API key), and processes the response.

Frontend:
- Created `OpenRouterPanel.vue`, a new component with fields for API key, model name, system prompt, and to display the diff and suggestions.
- Added a new step "Get Suggestions" (Step 5) to `MainLayout.vue`.
- Modified `CentralPanel.vue` to render `OpenRouterPanel.vue` for the new step.
- Handles loading states, error messages, and updates step completion.

The integration allows you to leverage models available via OpenRouter to review and get improvement ideas for your code diffs within the app.