### PR TITLE
Fix WSL clipboard crashes and encoding issues (Russian text + tree sy…

### DIFF
--- a/frontend/src/components/steps/Step2ComposePrompt.vue
+++ b/frontend/src/components/steps/Step2ComposePrompt.vue
@@ -113,7 +113,7 @@
 <script setup>
 import { ref, watch, onMounted, computed } from 'vue';
 import { ClipboardSetText as WailsClipboardSetText } from '../../../wailsjs/runtime/runtime';
-import { GetCustomPromptRules, SetCustomPromptRules } from '../../../wailsjs/go/main/App';
+import { GetCustomPromptRules, SetCustomPromptRules, WSLClipboardSetText } from '../../../wailsjs/go/main/App';
 import { LogInfo as LogInfoRuntime, LogError as LogErrorRuntime } from '../../../wailsjs/runtime/runtime';
 import CustomRulesModal from '../CustomRulesModal.vue';
 
@@ -282,16 +282,29 @@ watch(selectedPromptTemplateKey, () => {
 async function copyFinalPromptToClipboard() {
   if (!props.finalPrompt) return;
   try {
-    await navigator.clipboard.writeText(props.finalPrompt);
+    // Try WSL clipboard method first (best for WSL compatibility)
+    try {
+      await WSLClipboardSetText(props.finalPrompt);
+      console.log('Successfully copied final prompt using WSL clip.exe method');
+    } catch (wslError) {
+      console.warn('WSL clipboard failed, trying Wails API:', wslError);
+      try {
+        await WailsClipboardSetText(props.finalPrompt);
+        console.log('Successfully copied final prompt using Wails clipboard API');
+      } catch (wailsError) {
+        console.warn('Wails clipboard failed, falling back to browser API:', wailsError);
+        // Fallback to browser clipboard API
+        await navigator.clipboard.writeText(props.finalPrompt);
+        console.log('Successfully copied final prompt using browser clipboard API');
+      }
+    }
+    
     copyButtonText.value = 'Copied!';
     setTimeout(() => {
       copyButtonText.value = 'Copy All';
     }, 2000);
   } catch (err) {
-    console.error('Failed to copy final prompt: ', err);
-    if (props.platform === 'darwin' && err) {
-      console.error('darvin ClipboardSetText failed for final prompt:', err);
-    }
+    console.error('All clipboard methods failed for final prompt:', err);
     copyButtonText.value = 'Failed!';
     setTimeout(() => {
       copyButtonText.value = 'Copy All';


### PR DESCRIPTION
…mbols)

Problem:
- Application crashed when pasting large project contexts (700KB+) in WSL
- Russian text appeared as mojibake/кракозябры: "╨Э╨╛╨▓╤Л╨╡ ╤Ж╨╡╨╜╤В╤А╤Л"
- Project tree symbols corrupted: "тФФтФАтФА" instead of "├──"
- WSL applications can't directly access Windows clipboard for large data
- PowerShell command line argument limit (~8KB) exceeded with big texts

Root causes:
- UTF-8 vs Windows-1251/CP1252 encoding conflicts between WSL and Windows
- Box-drawing Unicode characters (├──, │, └──) not properly handled
- PowerShell clip.exe doesn't preserve UTF-8 encoding correctly
- Command line length limitations for large data

Solution:
✅ WSL-specific clipboard method using temporary files:
- Small data (<10KB): Direct PowerShell Set-Clipboard with proper UTF-8
- Large data (>10KB): Write to WSL /tmp, read via \\wsl$\distro\tmp\ path
- Fallback: WSL method → Wails API → Browser clipboard

✅ Fixed encoding issues:
- ASCII tree symbols: ├── → "|--", │ → "|", └── → "`--"
- PowerShell Set-Clipboard with -Encoding UTF8 flag
- Proper UTF-8 handling preserves Russian text correctly

✅ Three-tier fallback strategy in all Vue components:
- Step1PrepareContext.vue: Project context copying
- Step2ComposePrompt.vue: Final prompt copying
- Step4ApplyPatch.vue: Diff splitting copying

Technical implementation:
- WSL environment auto-detection via WSL_DISTRO_NAME
- Temporary files: /tmp/shotgun_clip_[timestamp].txt
- Windows access: \\wsl$\[distro]\tmp\ (+ \\wsl.localhost\ fallback)
- Proper cleanup and error handling with detailed logging
- PowerShell: Get-Content -Encoding UTF8 -Raw | Set-Clipboard

Results:
🎉 No more crashes when copying/pasting large projects (tested with 700KB+ data) 🎉 Russian text displays correctly: "Новые централизованные классы" 🎉 Clean ASCII tree structure in project output
🎉 Seamless WSL ↔ Windows clipboard integration
🎉 Maintains full backward compatibility

Tested environments:
- WSL2 Ubuntu on Windows 11
- Large projects: luckybot (~700KB), shotgun_code
- All clipboard operations: context, prompts, diffs